### PR TITLE
Bumped github action version as Node.js 16 actions are deprecated

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@main
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Install dependencies


### PR DESCRIPTION
Resolves Issues #37

Update the github action vesion

actions/checkout@v3 - Changed to @main
actions/setup-python@v3 - Changed to latest @v5



